### PR TITLE
Add string literal explanation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install --save typescript-string-enums
 ## Usage
 
 Define an enum as follows:
+
 ``` javascript
 // Status.ts
 import { Enum } from "typescript-string-enums";
@@ -20,7 +21,9 @@ import { Enum } from "typescript-string-enums";
 export const Status = Enum("RUNNING", "STOPPED");
 export type Status = Enum<typeof Status>;
 ```
+
 Use it elsewhere:
+
 ``` javascript
 import { Status } from "./Status";
 
@@ -58,39 +61,59 @@ function saySomethingAboutState(state: State) {
 
 ## Motivation
 
-Standard TypeScript enums are quite useful because they cleanly specify a type that can take one of
-finitely many values, and can be used as the discriminant in discriminated unions. For example:
+Enums are useful for cleanly specifying a type that can take one of a few specific values.
+TypeScript users typically implement enums in one of two ways: built-in
+[TypeScript enums](https://www.typescriptlang.org/docs/handbook/enums.html) or string literals, but
+each of these has drawbacks.
+
+### Why not built-in enums?
+
+Built-in enums have one big drawback. Their runtime value is a number, which is annoying during
+development and makes them unsuitable for use with external APIs.
+
 ``` javascript
 enum Status {
     RUNNING, STOPPED
 }
 
-interface RunningState {
-    status: Status.RUNNING;
-    pid: number;
-}
-
-interface StoppedState {
-    status: Status.STOPPED;
-    shutdownTime: Date;
-}
-
-function saySomethingAboutState(state: State) {
-    // The following typechecks.
-    if (state.status === Status.RUNNING) {
-        console.log("The pid is " + state.pid);
-    } else if (state.status === Status.STOPPED) {
-        console.log("The shutdown time is " + state.shutdownTime);
-    }
-}
+const state = { status: Status.RUNNING, pid: 12345 };
+console.log(state);
+// -> { status: 0, pid: 12345 }. What status was that again?
+// I hope you're not expecting other services to send you objects that look like this.
 ```
-However, such enums have one big drawback. Their runtime value is a number, which is annoying for
-development and prevents them from being used pleasantly with external APIs:
+
+### Why not string literals
+
+Using string literals throughout a program leaves it vulnerable to bugs caused by typos or
+incomplete refactors. For example:
+
 ``` javascript
-const state: RunningState = { status: Status.RUNNING, pid: 12345 };
-console.log(state); // -> { status: 0, pid: 12345 }. What status is that again?
+type Status = "RUNNING" | "STOPPED";
+
+...
+
+// Typo "SOTPPED" is not caught by typechecker.
+// Pretty bad bug- this block will never run.
+if (state.status === "SOTPPED") {
+    soundTheAlarm();
+}
 ```
-Developers might attempt to use a union of string literals instead, but this has drawbacks as well:
+
+Further, string literals make refactoring difficult. Suppose I have two enums:
+
+``` javascript
+type Status = "RUNNING" | "STOPPED";
+type TriathlonStage = "SWIMMING" | "CYCLING" | "RUNNING";
+```
+
+Then if at a later stage I want to change `Status` to be `"STARTED" | "STOPPED"`, there's no easy
+way to do it. I can't globally find/replace `"RUNNING"` to `"STARTED"` because it will also change
+the unrelated string constants representing `TriathlonStage`. Instead, I have to examine every
+occurrance of the string `"RUNNING"` to see if it needs to change.
+
+I might try to make this step easier by introducing constants for the string literals, but this has
+problems as well:
+
 ``` javascript
 type Status = "RUNNING" | "STOPPED";
 
@@ -110,13 +133,16 @@ const Status = {
     STOPPED: "STOPPED" as "STOPPED",
 };
 ```
-This library provides the convenience of built-in enums, but with string values intead of integers.
+
+This library is effectively a programmatic version of these repetitive definitions. It attempts to
+provide the best of both worlds: string enums with the convenience of built-in enums.
 
 ## How It Works
 
 This section is not necessary to use this library, but for those curious about how it is implemented, read on.
 
 The entire source of this library is
+
 ``` javascript
 export function Enum<V extends string>(...values: V[]): { [K in V]: K } {
     const result: any = {};
@@ -126,17 +152,21 @@ export function Enum<V extends string>(...values: V[]): { [K in V]: K } {
 
 export type Enum<T> = T[keyof T];
 ```
+
 We are creating a function named `Enum` and a type named `Enum`, so both can be imported with a single symbol.
 
 The type signature
+
 ``` javascript
 function Enum<V extends string>(...values: V[]): { [K in V]: K } {
 ```
+
 can be read as follows: take in an array of strings and call the different types `V`. A string
 constant is a type in TypeScript (for example, `const foo = "hello"` assigns the type `"hello"`
 to `foo`), so `V` is actually multiple string literal types. Then `{ [K in V]: K }` describes an
 object whose keys are the types that make up `V` and for each such key has a value equal to that
 key. Hence, the type of `Enum("RUNNING", "STOPPED")` is
+
 ``` javascript
 // This is a type, not an object literal.
 {
@@ -144,10 +174,13 @@ key. Hence, the type of `Enum("RUNNING", "STOPPED")` is
     STOPPED: "STOPPED";
 }
 ```
+
 Next, consider the definition
+
 ``` javascript
 type Enum<T> = T[keyof T];
 ```
+
 This describes, for a given keyed type `T`, the type obtained by taking the values of `T` when
 passing in each key (the syntax `T[keyof T]` is meant to evoke `t[key]` for each `key` in `t`). When
 applied to the type from the previous step, we end up with the union of the types of the values,


### PR DESCRIPTION
README now more thoroughly explains a reason to use this library over
string literals