### PR TITLE
Differing enum values

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -8,4 +8,11 @@ describe("Enum", () => {
     it("returns an object with values equal to keys given a single string", () => {
         expect(Enum("BLACK")).toEqual({ BLACK: "BLACK" });
     });
+
+    it("returns the original object given an object", () => {
+        expect(Enum({
+            BLACK: "black",
+            WHITE: "white",
+        })).toEqual({ BLACK: "black", WHITE: "white" });
+    });
 });

--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -1,7 +1,11 @@
 import { Enum } from "../src/index";
 
 describe("Enum", () => {
-    it("should return an object with values equal to keys", () => {
+    it("returns an object with values equal to keys given multiple strings", () => {
         expect(Enum("BLACK", "WHITE")).toEqual({ BLACK: "BLACK", WHITE: "WHITE" });
+    });
+
+    it("returns an object with values equal to keys given a single string", () => {
+        expect(Enum("BLACK")).toEqual({ BLACK: "BLACK" });
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,18 @@
-export function Enum<V extends string>(...values: V[]): { [K in V]: K } {
-    const result: any = {};
-    values.forEach((value) => result[value] = value);
-    return result;
+export function Enum<V extends string>(...values: V[]): { [K in V]: K };
+export function Enum<
+    T extends { [_: string]: V },
+    V extends string
+>(definition: T): T;
+export function Enum(...values: any[]): any {
+    if (typeof values[0] === "string") {
+        const result: any = {};
+        for (const value of values) {
+            result[value] = value;
+        }
+        return result;
+    } else {
+        return values[0];
+    }
 }
 
 export type Enum<T> = T[keyof T];


### PR DESCRIPTION
This fixes #5. It is more or less a merging of the original implementation of this module and [the example provided by @weswigham](https://github.com/Microsoft/TypeScript/issues/3192#issuecomment-261720275). The problem exhibited by [`WeirdEnum`](https://github.com/dphilipson/typescript-string-enums/issues/5#issuecomment-279182208) is solved by giving the function two type parameters, both of which are inferred by the TypeScript compiler. Additionally, the `forEach` call was replaced with `for-of` to allow this module to work even in an ES3 environment with no need for an ES5 `Array.prototype.forEach` polyfill.

There is still some room for improvement:
- TypeScript does not prohibit you from applying `keyof` to a non-object type. For instance, given `type Enum<T> = T[keyof T]`, one can write `Enum<number>` and not fail compilation. (The result is harmless, although meaningless: `number`.) If we raise the TypeScript dependency of this module from 2.1 to 2.2, we can use the [`object` type](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#object-type) as a constraint: `type Enum<T extends object> = T[keyof T]`.
- Introduce type-safe variants of `Object.keys` and `Object.values` to be used with these enum types. For example, given `const e = {a: 'A', b: 'B'}`, `Enum.keys(e)` should yield `('a' | 'b')[]` (instead of `string[]` like `Object.keys` does) and `Enum.values(e)` should yield `('A' | 'B')[]` (instead of `any[]` like `Object.values` does).

I believe this also solves #7, so long as you define an enum using the extended form:
```ts
export const Status = Enum({
  /**
   * The service is running and operational
   */
  RUNNING: 'running',

  /**
   * Something is wrong
   */
  STOPPED: 'stopped',
});
export type Status = Enum<typeof Status>;
```

Rather than the short form:
```ts
export const Status = Enum('running', 'stopped');
export type Status = Enum<typeof Status>;
```