### PR TITLE
Introduce Enum.{keys, values}

### DIFF
--- a/__tests__/test.ts
+++ b/__tests__/test.ts
@@ -16,3 +16,23 @@ describe("Enum", () => {
         })).toEqual({ BLACK: "black", WHITE: "white" });
     });
 });
+
+describe("Enum.keys", () => {
+    it("returns the keys of an enum object", () => {
+        const e = Enum({
+            BLACK: "black",
+            WHITE: "white",
+        });
+        expect(Enum.keys(e)).toEqual(expect.arrayContaining([ "WHITE", "BLACK" ]));
+    });
+};
+
+describe("Enum.values", () => {
+    it("returns the values of an enum object", () => {
+        const e = Enum({
+            BLACK: "black",
+            WHITE: "white",
+        });
+        expect(Enum.values(e)).toEqual(expect.arrayContaining([ "white", "black" ]));
+    });
+});

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jest": "^18.1.0",
     "ts-jest": "^18.0.1",
     "tslint": "^4.3.1",
-    "typescript": "^2.1.5"
+    "typescript": "^2.2.1"
   },
   "jest": {
     "transform": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export function Enum<
     T extends { [_: string]: V },
     V extends string
 >(definition: T): T;
-export function Enum(...values: any[]): any {
+export function Enum(...values: any[]): object {
     if (typeof values[0] === "string") {
         const result: any = {};
         for (const value of values) {
@@ -15,4 +15,4 @@ export function Enum(...values: any[]): any {
     }
 }
 
-export type Enum<T> = T[keyof T];
+export type Enum<T extends object> = T[keyof T];

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,31 @@ export function Enum(...values: any[]): object {
 }
 
 export type Enum<T extends object> = T[keyof T];
+
+export namespace Enum {
+    function hasOwnProperty(obj: object, prop: string): boolean {
+        return Object.prototype.hasOwnProperty.call(obj, prop);
+    }
+
+    export function keys<
+        T extends { [_: string]: any }
+    >(e: T): Array<keyof T> {
+        const result: string[] = [];
+        for (const prop in e) {
+            if (hasOwnProperty(e, prop)) {
+                result.push(prop);
+            }
+        }
+        return result as Array<keyof T>;
+    }
+
+    export function values<
+        T extends { [_: string]: any }
+    >(e: T): Array<Enum<T>> {
+        const result: Array<Enum<T>> = [];
+        for (const key of keys(e)) {
+            result.push(e[key as string]);
+        }
+        return result;
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
 		"interface-name": [
 			true, "never-prefix"
 		],
+		"no-namespace": false,
 		"object-literal-sort-keys": false
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2472,9 +2472,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.5.tgz#6fe9479e00e01855247cea216e7561bafcdbcd4a"
+typescript@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
 
 uglify-js@^2.6:
   version "2.7.5"


### PR DESCRIPTION
Adds more type safety by disallowing nonsensical types like `Enum<number>` or `Enum<boolean>`. This is achieved by constraining the definition to `type Enum<T extends object> = T[keyof T]`, where [`object`](https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#object-type) is a new type introduced in TypeScript 2.2.

Also introduces `Enum.keys` and `Enum.values`. They are equivalent to `Object.keys` and `Object.values`, except they are type safe and work in an ES3 environment without any ES5 polyfill.

Example usage:
```ts
const FileType = Enum({
  PDF: 'application/pdf',
  Text: 'text/plain',
  JPEG: 'image/jpeg'
});
type FileType = Enum<typeof FileType>;

const keys = Enum.keys(FileType);
// Inferred type: ('PDF' | 'Text' | 'JPEG')[]
// Return value: ['PDF', 'Text', 'JPEG'] (not necessarily in that order)

const values = Enum.values(FileType);
// Inferred type: ('application/pdf' | 'text/plain' | 'image/jpeg')[]
// Return value: ['application/pdf', 'text/plain', 'image/jpeg'] (not necessarily in that order)
```